### PR TITLE
Remove redundant nil checks

### DIFF
--- a/help.go
+++ b/help.go
@@ -237,10 +237,8 @@ func printHelpCustom(out io.Writer, templ string, data interface{}, customFunc m
 	funcMap := template.FuncMap{
 		"join": strings.Join,
 	}
-	if customFunc != nil {
-		for key, value := range customFunc {
-			funcMap[key] = value
-		}
+	for key, value := range customFunc {
+		funcMap[key] = value
 	}
 
 	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)